### PR TITLE
chore: lock KlarnaMobileSDK to v2.0.8

### DIFF
--- a/react-native-klarna-inapp-sdk.podspec
+++ b/react-native-klarna-inapp-sdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency 'KlarnaMobileSDK', '~> 2.0.10'
+  s.dependency 'KlarnaMobileSDK', '2.0.8'
   # s.dependency "..."
 end
 


### PR DESCRIPTION
This allows app to launch correctly in iOS12.2 and under.