### PR TITLE
fix(WebView): fix android web view takes up width of entire screen

### DIFF
--- a/android/src/main/java/com/klarna/inapp/sdk/PaymentViewWrapper.java
+++ b/android/src/main/java/com/klarna/inapp/sdk/PaymentViewWrapper.java
@@ -65,7 +65,7 @@ public class PaymentViewWrapper extends LinearLayout {
             return;
         }
 
-        final int viewWidth = getParentViewWidth();
+        final int viewWidth = getParentViewWidth() - 150;
 
         // Note: window.innerHeight, document.body.getClientBoundingRect(), etc... don't return the
         // right value.


### PR DESCRIPTION
[ticket](https://jira.brandingbrand.com/browse/ARCADIA-2861)

## Description
The margin we set to the Klarna container is overwritten by the SDK. Change was made so that the padding would apply on Android as well.

## STR
1. On arcadia repo, find the file `node_modules/react-native-klarna-inapp-sdk/android/src/main/java/com/klarna/inapp/sdk/PaymentViewWrapper.java`
2. update line68 to be `final int viewWidth = getParentViewWidth() - 150;` 
3. in `paymentMethodModal.tsx`, remove `Platform.OS !== 'android'` on line 118
4. run `yarn`, `yarn run init --brand tsuk`, and `yarn run tsc`.
5. run `yarn run ios` and run `yarn run android`
6. add something to cart and go through the checkout flow.
7. select klarna to be the payment method. 
8. select either **pay later** or **pay over time**
9. observe the padding

### ER
padding is applied in both ios and android.

## Screenshots
Android
![Screenshot_1585598451](https://user-images.githubusercontent.com/51350319/77958172-a236f300-72a2-11ea-8ce7-384a64f0b175.png)
![Screenshot_1585598319](https://user-images.githubusercontent.com/51350319/77958174-a2cf8980-72a2-11ea-9e37-ada50c7dd1e6.png)

ios
![Simulator Screen Shot - iPhone X - 2020-03-30 at 16 29 11](https://user-images.githubusercontent.com/51350319/77958806-9ac41980-72a3-11ea-8874-a97d74d91de7.png)
![Simulator Screen Shot - iPhone X - 2020-03-30 at 16 29 02](https://user-images.githubusercontent.com/51350319/77958807-9b5cb000-72a3-11ea-9d3f-ca780ec9b33d.png)
